### PR TITLE
Upgrade PageCrypt, remove Node v19 restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,9 @@
   "author": "Render Developers",
   "license": "MIT",
   "engines": {
-    "node": ">=16 <19"
+    "node": ">=16"
   },
   "dependencies": {
-    "pagecrypt": "^5.3.0"
+    "pagecrypt": "^6.1.1"
   }
 }
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,20 +7,20 @@ mri@^1.1.0:
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
   integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
-pagecrypt@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/pagecrypt/-/pagecrypt-5.3.0.tgz#d6bb4e129e405e5df3dfb412c49b5911f15d342f"
-  integrity sha512-2N0IRglSe5KTGIYF9xY3CjfmeXu8yxRlf+HCHpAfP2Qd9N7FVuQ7Q/aA8x8WkCwRHIfu71x64bq9YweVCFlMYA==
+pagecrypt@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/pagecrypt/-/pagecrypt-6.1.1.tgz#7600b3feb0dd3165dba591c1abd58db856dfcd10"
+  integrity sha512-ai5VtSxJDWPRJrkWe8IVEPPLMd9OZM6DdmtNNwOxmq/M6Fm/XXuygdlDeSr6T0XTBAk5LQHIGGkHBjR6tfr9iQ==
   dependencies:
-    rfc4648 "^1.5.0"
-    sade "^1.7.4"
+    rfc4648 "^1.5.2"
+    sade "^1.8.1"
 
-rfc4648@^1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/rfc4648/-/rfc4648-1.5.1.tgz#b0b16756e33d9de8c0c7833e94b28e627ec372a4"
-  integrity sha512-60e/YWs2/D3MV1ErdjhJHcmlgnyLUiG4X/14dgsfm9/zmCWLN16xI6YqJYSCd/OANM7bUNzJqPY5B8/02S9Ibw==
+rfc4648@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/rfc4648/-/rfc4648-1.5.2.tgz#cf5dac417dd83e7f4debf52e3797a723c1373383"
+  integrity sha512-tLOizhR6YGovrEBLatX1sdcuhoSCXddw3mqNVAcKxGJ+J0hFeJ+SjeWCv5UPA/WU3YzWPPuCVYgXBKZUPGpKtg==
 
-sade@^1.7.4:
+sade@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/sade/-/sade-1.8.1.tgz#0a78e81d658d394887be57d2a409bf703a3b2701"
   integrity sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==


### PR DESCRIPTION
Previously, this example did not work with Node version 19 (#1). #2 specified `engines.node` to `>=16 <19`.

PageCrypt version 6.0.0 is now compatible with Node 19.

This PR loosens the `engines.node` restriction and upgrades the `pagecrypt` dependency.

I tested this with both Node 16 and 19:

```sh
nvm use 19
PASSWORD=1234 yarn build
# builds successfully

nvm use 16
PASSWORD=1234 yarn build
# builds successfully

```